### PR TITLE
Updating stripe NPM dependency to 3.7.0

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,16 +1,16 @@
 {
   "dependencies": {
     "stripe": {
-      "version": "http://registry.npmjs.org/stripe/-/stripe-3.2.0.tgz",
+      "version": "3.7.0",
       "dependencies": {
         "bluebird": {
-          "version": "2.9.9"
+          "version": "2.9.34"
         },
         "qs": {
-          "version": "2.3.3"
+          "version": "2.4.2"
         },
         "lodash": {
-          "version": "3.2.0"
+          "version": "3.10.0"
         }
       }
     }

--- a/package.js
+++ b/package.js
@@ -5,7 +5,7 @@ Package.describe({
 	git: "https://github.com/tyler-johnson/stripe-meteor.git"
 });
 
-Npm.depends({ "stripe": "3.2.0" });
+Npm.depends({ "stripe": "3.7.0" });
 
 Package.onUse(function(api) {
 	api.versionsFrom('1.0.1');


### PR DESCRIPTION
This fixes an issue I'm having with `Stripe.customers.createSource` not existing on the server.