### PR TITLE
Prevent loading of Stripe dependencies on all pages

### DIFF
--- a/package.js
+++ b/package.js
@@ -11,7 +11,6 @@ Package.onUse(function(api) {
 	api.versionsFrom('1.0.1');
 	if (api.export) api.export('STRIPEMETEOR');
 	api.use(['templating'], 'client');
-	api.addFiles('stripe_client.html', 'client');
 	api.addFiles('stripe_server.js', 'server');
 });
 

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
 	summary: "Stripe.js and Node-Stripe brought to Meteor.",
 	version: "2.1.0",
-	name: "mendelyev:stripe",
-	git: "https://github.com/MendelYev/stripe-meteor.git"
+	name: "mrgalaxy:stripe",
+-	git: "https://github.com/tyler-johnson/stripe-meteor.git"
 });
 
 Npm.depends({ "stripe": "3.2.0" });

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
 	summary: "Stripe.js and Node-Stripe brought to Meteor.",
 	version: "2.1.0",
-	name: "mrgalaxy:stripe",
-	git: "https://github.com/tyler-johnson/stripe-meteor.git"
+	name: "mendelyev:stripe",
+	git: "https://github.com/MendelYev/stripe-meteor.git"
 });
 
 Npm.depends({ "stripe": "3.2.0" });

--- a/stripe_client.html
+++ b/stripe_client.html
@@ -1,4 +1,0 @@
-<head>
-	<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
-	<script type="text/javascript" src="https://checkout.stripe.com/checkout.js"></script>
-</head>


### PR DESCRIPTION
stripe.js and checkout.js are loaded in all pages since they are imported in the header.
Instead, you could use :
- the $.getScript() jQuery function in a Template.mytemplate.rendered block
- wait-on-lib package which allows to import your dependencies directly from iron-router

These are well explained there : http://www.meteorsnippets.com/blog/add-external-scripts-in-meteor

But this pull request will probably break the client tests...
