### PR TITLE
Async tag breaks Stripe functionality in some cases. Must be reverted.

### DIFF
--- a/stripe_client.html
+++ b/stripe_client.html
@@ -1,4 +1,4 @@
 <head>
-	<script async type="text/javascript" src="https://js.stripe.com/v2/"></script>
-	<script async type="text/javascript" src="https://checkout.stripe.com/checkout.js"></script>
+	<script type="text/javascript" src="https://js.stripe.com/v2/"></script>
+	<script type="text/javascript" src="https://checkout.stripe.com/checkout.js"></script>
 </head>


### PR DESCRIPTION
@tyler-johnson This should be pushed asap. My previous commit could create problems.

Revert "Added async attribute to speed up page load" 

This reverts commit fcb299df5b40687708e5b442c1485180863c53ba.